### PR TITLE
Fix Japanese line breaks on landing page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -110,6 +110,10 @@ const currentYear = new Date().getFullYear();
         max-width: 36rem;
       }
 
+      .whisper span {
+        display: block;
+      }
+
       footer {
         font-size: 0.75rem;
         padding: 0 1.5rem 1.5rem;
@@ -181,8 +185,8 @@ const currentYear = new Date().getFullYear();
           <em>in preparation</em>
         </h1>
         <p class="whisper">
-          すべての責任ある人々のため、手元で息づく新しいカラクリが<br />
-          静かに鼓動しています。
+          <span>すべての責任ある人々のため、手元で息づく</span>
+          <span>新しいカラクリが静かに鼓動しています。</span>
         </p>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- remove the manual `<br>` from the hero description and wrap each sentence in its own span
- add styling so each span renders on its own line for natural Japanese line breaks
- adjust the sentence split so "カラクリが" stays with the following phrase for natural flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7501220c8320969f64b1689349e0