### PR TITLE
Switch homepage background to cool gradient

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,10 +12,10 @@ const currentYear = new Date().getFullYear();
       :root {
         color-scheme: dark;
         font-family: "Inter", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
-        background: radial-gradient(circle at 18% 22%, rgba(144, 96, 55, 0.16), transparent 55%),
-          radial-gradient(circle at 78% 18%, rgba(92, 65, 42, 0.18), transparent 58%),
-          linear-gradient(140deg, #1e120b, #3a2314 52%, #1b0f08);
-        color: rgba(248, 236, 222, 0.82);
+        background: radial-gradient(circle at 18% 22%, rgba(74, 126, 178, 0.24), transparent 55%),
+          radial-gradient(circle at 78% 18%, rgba(34, 105, 168, 0.28), transparent 58%),
+          linear-gradient(140deg, #041b36, #0b2748 52%, #06172b);
+        color: rgba(224, 236, 250, 0.84);
       }
 
       body {
@@ -58,9 +58,9 @@ const currentYear = new Date().getFullYear();
         width: clamp(3rem, 5vw, 3.75rem);
         aspect-ratio: 1;
         border-radius: 18%;
-        background: linear-gradient(135deg, rgba(146, 94, 58, 0.55), rgba(203, 147, 94, 0.35));
-        border: 1px solid rgba(255, 235, 210, 0.12);
-        box-shadow: 0 14px 38px rgba(30, 16, 7, 0.55);
+        background: linear-gradient(135deg, rgba(74, 134, 194, 0.55), rgba(128, 182, 228, 0.32));
+        border: 1px solid rgba(207, 227, 255, 0.18);
+        box-shadow: 0 14px 38px rgba(3, 26, 56, 0.55);
         position: relative;
       }
 
@@ -89,7 +89,7 @@ const currentYear = new Date().getFullYear();
       h1 em {
         font-style: normal;
         font-weight: inherit;
-        color: rgba(244, 222, 197, 0.65);
+        color: rgba(201, 222, 247, 0.68);
         letter-spacing: 0.34em;
         text-transform: uppercase;
         font-size: clamp(0.7rem, 1.2vw, 0.9rem);
@@ -99,14 +99,14 @@ const currentYear = new Date().getFullYear();
         margin: 0;
         font-size: 1rem;
         line-height: 1.7;
-        color: rgba(245, 231, 214, 0.8);
+        color: rgba(219, 232, 247, 0.82);
       }
 
       .whisper {
         margin: 0;
         font-size: clamp(1.05rem, 2.1vw, 1.35rem);
         line-height: 1.85;
-        color: rgba(249, 233, 212, 0.88);
+        color: rgba(214, 232, 250, 0.9);
         max-width: 36rem;
       }
 
@@ -119,7 +119,7 @@ const currentYear = new Date().getFullYear();
         padding: 0 1.5rem 1.5rem;
         display: flex;
         justify-content: center;
-        color: rgba(231, 210, 188, 0.46);
+        color: rgba(193, 214, 236, 0.5);
       }
 
       footer span {
@@ -132,7 +132,7 @@ const currentYear = new Date().getFullYear();
       footer svg {
         width: 0.75rem;
         height: 0.75rem;
-        opacity: 0.45;
+        opacity: 0.5;
       }
 
       .trace {


### PR DESCRIPTION
## Summary
- restyle the homepage root background with layered cool-toned gradients
- adjust accent and text colors to complement the cooler palette

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132c737d88832e91f5a76fd81da217)